### PR TITLE
Added win32 to the supported platforms.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     },
     "os": [
         "darwin",
-        "linux"
+        "linux",
+        "win32"
     ],
     "main": "./minify.json.js"
 }


### PR DESCRIPTION
I tested the module direct statically a project of mine, where it works like a charm. Since it doesn't rely on any platform-specific I expect it will work on all platforms.

You can see a working example here:
https://github.com/branneman/frontend-bootstrap/compare/improved-jshintrc
